### PR TITLE
Use URLs for Redis connections

### DIFF
--- a/lib/planetstream.js
+++ b/lib/planetstream.js
@@ -15,10 +15,9 @@ function PlanetStream (opts) {
   var log = new Log(process.env.LOG_LEVEL || 'info');
   opts.log = log;
 
-  var host = opts.host || '127.0.0.1';
-  var port = opts.port || 6379;
+  var redisUrl = opts.redisUrl || 'redis://localhost/'
 
-  var redis = new Redis(port, host);
+  var redis = new Redis(redisUrl);
   var metaStream = MetaStream(opts);
   var dataStream = DataStream(opts); 
   var metaPipeline = redis.pipeline();
@@ -28,10 +27,7 @@ function PlanetStream (opts) {
    */
   var queue = kue.createQueue({
     prefix: 'q',
-    redis: {
-      port: port,
-      host: host
-    },
+    redis: redisUrl,
     jobEvents: false
   });
 


### PR DESCRIPTION
This enables password authentication and the use of non-default dbs.

It also requires a semver-minor bump since it changes the API.